### PR TITLE
Update Package Versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,15 +20,15 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "^0.9.2",
-    "grunt-contrib-clean": "^0.5.0",
-    "grunt-contrib-nodeunit": "^0.3.3",
-    "grunt": "~0.4.5"
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-nodeunit": "^1.0.0",
+    "grunt": "~1.0.1"
   },
   "keywords": [
     "gruntplugin"
   ],
   "dependencies": {
-    "typings-core": "^0.2.10"
+    "typings-core": "^1.0.1"
   }
 }

--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,5 @@
 {
-  "ambientDependencies": {
+  "globalDependencies": {
     "react": "github:DefinitelyTyped/DefinitelyTyped/react/react.d.ts#f407264835650f5f38d4bb2c515a79e7a835916b"
   }
 }


### PR DESCRIPTION
Update both the version of Grunt (1.0.0 is now released) and move to typings/core 1.0.1.

Fixes #5 
